### PR TITLE
Fix file path for settings and markdown guide

### DIFF
--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -86,7 +86,7 @@ class Setup extends Command
 
     private function createDefaultSettingsFile()
     {
-        $settingsFilePath = storage_path('app\\settings.json');
+        $settingsFilePath = storage_path('app//settings.json');
 
         if (file_exists($settingsFilePath)) {
             $this->info('Settings file already exists, skipping.');

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -93,6 +93,8 @@ class Setup extends Command
             return;
         }
 
+        $this->info('Settings file: ' . $settingsFilePath . ' - does NOT exist!');
+
         $defaultSettings = [
             'enable_user_registration' => false,
             'show_home_page' => true

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -62,7 +62,7 @@ class Setup extends Command
 
     private function createDefaultMarkdownGuide()
     {
-        $mdGuidePath = base_path() . '\\MarkdownGuide.md';
+        $mdGuidePath = base_path() . '//MarkdownGuide.md';
 
         if (StaticPage::where('slug', 'markdown-guide')->first()) {
             $this->info('Markdown Guide already exists, skipping.');
@@ -92,8 +92,6 @@ class Setup extends Command
             $this->info('Settings file already exists, skipping.');
             return;
         }
-
-        $this->info('Settings file: ' . $settingsFilePath . ' - does NOT exist!');
 
         $defaultSettings = [
             'enable_user_registration' => false,


### PR DESCRIPTION
This fixes a bug where when re-deploying and running `php artisan notebook:setup`, the `MarkdownGuide.md` file would not be found, thus not creating the static page, and your existing `settings.json` file would not be found and your settings would be overwritten with the default settings.